### PR TITLE
add empty strings for path and port in default API endpoint config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,8 @@ default['uchiwa']['api'] = [
   {
     'name' => 'Sensu',
     'host' => '127.0.0.1',
+    'port' => 4567,
+    'path' => '',
     'ssl' => false,
     'timeout' => 5000
   }


### PR DESCRIPTION
This fixes issue #2 by supplying default values to port and path for API configuration. Without these values the default config causes Uchiwa to generate bad URLs
