### PR TITLE
Chef client fail with the lastest changes 

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 include_recipe "uchiwa::#{node['uchiwa']['install_method']}"
 
 # Generate config file
-settings = []
+settings = {}
 node['uchiwa']['settings'].each do |k, v|
   settings[k] = v
 end


### PR DESCRIPTION
Hi,

There is an error in the default recipe. The chef-client command fails with the following error:

```
TypeError
---------
can't convert String into Integer


Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/uchiwa/recipes/default.rb:24:in `[]='
  /var/chef/cache/cookbooks/uchiwa/recipes/default.rb:24:in `block in from_file'
  /var/chef/cache/cookbooks/uchiwa/recipes/default.rb:23:in `each'
  /var/chef/cache/cookbooks/uchiwa/recipes/default.rb:23:in `from_file'


Relevant File Content:
----------------------
/var/chef/cache/cookbooks/uchiwa/recipes/default.rb:

 17:  # limitations under the License.
 18:  
 19:  include_recipe "uchiwa::#{node['uchiwa']['install_method']}"
 20:  
 21:  # Generate config file
 22:  settings = []
 23:  node['uchiwa']['settings'].each do |k, v|
 24>>   settings[k] = v
 25:  end
 26:  config = { 'uchiwa' => settings, 'sensu' => node['uchiwa']['api'] }
27:  
28:  template "#{node['uchiwa']['sensu_homedir']}/uchiwa.json" do
29:    user node['uchiwa']['owner']
30:    group node['uchiwa']['group']
31:    mode 0640
32:    notifies :restart, 'service[uchiwa]'
33:    variables(:config => JSON.pretty_generate(config)) 
```

I requested a pull with the fix for this issue.
