### PR TITLE
properly configure defaults uchiwa config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ default['uchiwa']['api'] = [
   {
     'name' => 'Sensu',
     'host' => '127.0.0.1',
-    'port' => 4567,
+    'url' => 'http://127.0.0.1:4567',
     'path' => '',
     'ssl' => false,
     'timeout' => 5


### PR DESCRIPTION
Uchiwa would like to use the URL parameter to talk to the sensu-api this sets a sane default.