### PR TITLE
Ensure service is restarted if package version has changed

### DIFF
--- a/recipes/http.rb
+++ b/recipes/http.rb
@@ -38,6 +38,7 @@ when 'debian'
   dpkg_package pkg do
     options package_options
     source "#{Chef::Config[:file_cache_path]}/#{pkg}"
+    notifies :restart, 'service[uchiwa]' if node['uchiwa']['manage_service']
   end
 when 'rhel'
   package_options = node['uchiwa']['package_options'] || '--nogpgcheck'
@@ -58,6 +59,7 @@ when 'rhel'
   package pkg do
     options package_options
     source "#{Chef::Config[:file_cache_path]}/#{pkg}"
+    notifies :restart, 'service[uchiwa]' if node['uchiwa']['manage_service']
   end
 else
   raise "Unsupported platform family #{node['platform_family']}. Aborting."

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -56,4 +56,5 @@ package_options = node['uchiwa']['package_options'] || package_options
 package 'uchiwa' do
   options package_options
   version node['uchiwa']['version']
+  notifies :restart, 'service[uchiwa]' if node['uchiwa']['manage_service']
 end


### PR DESCRIPTION
At present if you change the uchiwa attribute from 0.4.1 to 0.6.0 on an existing server the package will be changed but the service will not be restarted