### PR TITLE
this part of the config is now an array of hashes

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ settings = {}
 node['uchiwa']['settings'].each do |k, v|
   settings[k] = v
 end
-config = { 'uchiwa' => settings, 'sensu' => node['uchiwa']['api'] }
+config = { 'uchiwa' => settings, 'sensu' => [ node['uchiwa']['api'] ] }
 
 template "#{node['uchiwa']['sensu_homedir']}/uchiwa.json" do
   user node['uchiwa']['owner']


### PR DESCRIPTION
Cookbook was creating invalid uchiwa config file.. 

previously creating
```
{
  "uchiwa": {
    "user": "admin",
    "pass": "supersecret",
    "refresh": 5,
    "host": "0.0.0.0",
    "port": 3000
  },
  "sensu":  {
      "name": "Sensu",
      "host": "localhost",
      "url": "http://localhost:4567"
    }
}
```

However, as the documentation states the "sensu" section should now be an array of hashes.

```
{
  "uchiwa": {
    "user": "admin",
    "pass": "supersecret",
    "refresh": 5,
    "host": "0.0.0.0",
    "port": 3000
  },
  "sensu": [
    {
      "name": "Sensu",
      "host": "localhost",
      "url": "http://localhost:4567"
    }
  ]
}
```

http://docs.uchiwa.io/en/latest/configuration/examples/#complete-configuration