### PR TITLE
Revert "this part of the config is now an array of hashes"

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ settings = {}
 node['uchiwa']['settings'].each do |k, v|
   settings[k] = v
 end
-config = { 'uchiwa' => settings, 'sensu' => [ node['uchiwa']['api'] ] }
+config = { 'uchiwa' => settings, 'sensu' => node['uchiwa']['api'] }
 
 template "#{node['uchiwa']['sensu_homedir']}/uchiwa.json" do
   user node['uchiwa']['owner']


### PR DESCRIPTION
Reverts sensu/uchiwa-chef#35

Config should already contain an array of hashes so long as `node["uchiwa"]["api"]` is set correctly. See: https://github.com/sensu/uchiwa-chef/blob/master/attributes/default.rb#L25-L34