### PR TITLE
Allow no authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,23 @@ The cookbook supports the following installation methods:
 + repo (default)
 + http
 
-# Supported plateforms
+# Attributes
 
-These plateforms have been tested successfully.
+You can change the following attributes to configure uchiwa:
+
+```
+default['uchiwa']['settings']['user'] = 'admin'
+default['uchiwa']['settings']['pass'] = 'supersecret'
+default['uchiwa']['settings']['refresh'] = 5
+default['uchiwa']['settings']['host'] = '0.0.0.0'
+default['uchiwa']['settings']['port'] = 3000
+```
+
+> To disable authentication on uchiwa, set user and pass to *nil*
+
+# Supported platforms
+
+These platforms have been tested successfully.
 
 + Centos/RHEL 6 and 7 x86_64
 + Ubuntu 12.04 and 14.04 amd64

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'amd.prophet@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures uchiwa'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.0'
+version          '1.1.1'
 
 depends          'yum'
 depends          'apt'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,15 @@ settings = {}
 node['uchiwa']['settings'].each do |k, v|
   settings[k] = v
 end
+
+# if the user or pass keys are nil, then
+# authentication will be disabled (by not
+# setting the user/pass parameters)
+if settings['user'].nil? or settings['pass'].nil? then
+  settings.delete('user')
+  settings.delete('pass')
+end
+
 config = { 'uchiwa' => settings, 'sensu' => node['uchiwa']['api'] }
 
 template "#{node['uchiwa']['sensu_homedir']}/uchiwa.json" do


### PR DESCRIPTION
Allows for the parameters for user and password to
be set to nil, which will then disable authentication
in uchiwa.