### PR TITLE
Allow disabling Uchiwa authentication

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@ include_recipe "uchiwa::#{node['uchiwa']['install_method']}"
 # Generate config file
 settings = {}
 node['uchiwa']['settings'].each do |k, v|
-  settings[k] = v
+  settings[k] = v unless v.nil?
 end
 config = { 'uchiwa' => settings, 'sensu' => node['uchiwa']['api'] }
 


### PR DESCRIPTION
To disable authentication in Uchiwa you simply remove the user and pass keys in the Uchiwa configuration. This change prevents null set node['uchiwa']['settings'] attributes from being included in /etc/sensu/uchiwa.json. Therefore, to disable authentication simply set the user and pass Chef attributes to nil. 