### PR TITLE
Allow uchiwa to use chef-vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ uchiwa Cookbook CHANGELOG
 =========================
 This file is used to list changes made in each version of the uchiwa cookbook.
 
+## [Unreleased]
+### Added
+- `libraries/uchiwa_helpers.rb`: Add the ability to store settings in chef-vault
+
 v1.4.0 (2017-09-16)
 -------------------
 - add the ability to optionally store uchiwa settings in a databag (supports encrypted data bags)

--- a/libraries/uchiwa_helpers.rb
+++ b/libraries/uchiwa_helpers.rb
@@ -4,21 +4,15 @@ module Uchiwa
     extend ChefVaultCookbook if Kernel.const_defined?("ChefVaultCookbook")
     def self.data_bag_item(data_bag_name, data_bag_item, missing_ok=false)
 
-      raw_hash = Chef::DataBagItem.load(data_bag_name, data_bag_item)
-      encrypted = raw_hash.detect do |key, value|
-        if value.is_a?(Hash)
-          value.has_key?("encrypted_data")
-        end
-      end
-      if encrypted
-        if Chef::DataBag.load(data_bag_name).key? "#{data_bag_item}_keys"
-          chef_vault_item(data_bag_name, data_bag_item)
-        else
-          secret = Chef::EncryptedDataBagItem.load_secret
-          Chef::EncryptedDataBagItem.new(raw_hash, secret)
-        end
-      else
-        raw_hash
+      case ChefVault::Item.data_bag_item_type(data_bag_name, data_bag_item)
+      when :normal
+        Chef::DataBagItem.load(data_bag_name, data_bag_item)
+      when :encrypted
+        raw_hash = Chef::DataBagItem.load(data_bag_name, data_bag_item)
+        secret = Chef::EncryptedDataBagItem.load_secret
+        Chef::EncryptedDataBagItem.new(raw_hash, secret)
+      when :vault
+        chef_vault_item(data_bag_name, data_bag_item)
       end
 
     rescue Chef::Exceptions::ValidationFailed,

--- a/libraries/uchiwa_helpers.rb
+++ b/libraries/uchiwa_helpers.rb
@@ -1,9 +1,25 @@
 module Uchiwa
   module Helpers
 
+    extend ChefVaultCookbook if Kernel.const_defined?("ChefVaultCookbook")
     def self.data_bag_item(data_bag_name, data_bag_item, missing_ok=false)
 
-      Chef::EncryptedDataBagItem.load(data_bag_name, data_bag_item).to_hash.delete_if { |key, value| key == 'id' }
+      raw_hash = Chef::DataBagItem.load(data_bag_name, data_bag_item)
+      encrypted = raw_hash.detect do |key, value|
+        if value.is_a?(Hash)
+          value.has_key?("encrypted_data")
+        end
+      end
+      if encrypted
+        if Chef::DataBag.load(data_bag_name).key? "#{data_bag_item}_keys"
+          chef_vault_item(data_bag_name, data_bag_item)
+        else
+          secret = Chef::EncryptedDataBagItem.load_secret
+          Chef::EncryptedDataBagItem.new(raw_hash, secret)
+        end
+      else
+        raw_hash
+      end
 
     rescue Chef::Exceptions::ValidationFailed,
         Chef::Exceptions::InvalidDataBagPath,

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,7 @@ version          '1.4.0'
 
 depends          'yum'
 depends          'apt'
+depends 'chef-vault', '>= 1.3.1'
 
 %w(
   ubuntu


### PR DESCRIPTION
### Description

Allow uchiwa to use chef-vault.

### Issues Resolved

Fix #60 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable