### PR TITLE
add exception to rescue clause

### DIFF
--- a/libraries/uchiwa_helpers.rb
+++ b/libraries/uchiwa_helpers.rb
@@ -17,6 +17,7 @@ module Uchiwa
 
     rescue Chef::Exceptions::ValidationFailed,
         Chef::Exceptions::InvalidDataBagPath,
+        Chef::Exceptions::InvalidDataBagItemID,
         Net::HTTPServerException => error
       missing_ok ? nil : raise(error)
     end


### PR DESCRIPTION
### Description

At some point the exception that gets raised when a data bag doesn't exist changed. It looks like this happened in chef/chef@8f5f95b. This PR adds the new exception to the `rescue` in `Uchiwa::Helpers.data_bag_item`.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable