### PR TITLE
Start using the eol repos

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,8 @@
 # Global
 default['uchiwa']['version'] = '0.23.1-1'
 default['uchiwa']['install_method'] = 'repo'
-default['uchiwa']['apt_repo_url'] = 'http://repositories.sensuapp.org/apt'
-default['uchiwa']['yum_repo_url'] = 'http://repositories.sensuapp.org'
+default['uchiwa']['apt_repo_url'] = 'http://eol-repositories.sensuapp.org/apt'
+default['uchiwa']['yum_repo_url'] = 'http://eol-repositories.sensuapp.org'
 default['uchiwa']['use_unstable_repo'] = false
 default['uchiwa']['http_url'] = 'http://dl.bintray.com/palourde/uchiwa'
 default['uchiwa']['owner'] = 'uchiwa'


### PR DESCRIPTION
### Description

Sensu repos move to http://eol-repositories.sensuapp.org/ on Jan 6, 2020.
https://blog.sensu.io/announcing-the-sensu-archives

### Issues Resolved
n/a

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable