### PR TITLE
Add ChefVault::Exceptions::ItemNotFound due to chef-vault change.

### DIFF
--- a/libraries/uchiwa_helpers.rb
+++ b/libraries/uchiwa_helpers.rb
@@ -18,6 +18,7 @@ module Uchiwa
     rescue Chef::Exceptions::ValidationFailed,
         Chef::Exceptions::InvalidDataBagPath,
         Chef::Exceptions::InvalidDataBagItemID,
+        ChefVault::Exceptions::ItemNotFound,
         Net::HTTPServerException => error
       missing_ok ? nil : raise(error)
     end


### PR DESCRIPTION
# Description

chef-vault v4.0.6 changed the exception thrown when a data bag/item does not exist to ChefVault::Exceptions::ItemNotFound.

See https://github.com/chef/chef-vault/pull/350/files

```
  ================================================================================
  Recipe Compile Error in /var/chef/cache/cookbooks/monitoring-sensu-rolebook/recipes/default.rb
  ================================================================================

  ChefVault::Exceptions::ItemNotFound
  -----------------------------------
  uchiwa/config not found

  Cookbook Trace:
  ---------------
    /var/chef/cache/cookbooks/uchiwa/libraries/uchiwa_helpers.rb:7:in `data_bag_item'
    /var/chef/cache/cookbooks/uchiwa/recipes/default.rb:33:in `from_file'
    /var/chef/cache/cookbooks/socrata-monitor-dashboard/recipes/default.rb:6:in `from_file'
    /var/chef/cache/cookbooks/monitoring-sensu-rolebook/recipes/default.rb:11:in `from_file'

  Relevant File Content:
  ----------------------
  /var/chef/cache/cookbooks/uchiwa/libraries/uchiwa_helpers.rb:

    1:  module Uchiwa
    2:    module Helpers
    3:
    4:      extend ChefVaultCookbook if Kernel.const_defined?("ChefVaultCookbook")
    5:      def self.data_bag_item(data_bag_name, data_bag_item, missing_ok=false)
    6:
    7>>       case ChefVault::Item.data_bag_item_type(data_bag_name, data_bag_item)
    8:        when :normal
    9:          Chef::DataBagItem.load(data_bag_name, data_bag_item)
   10:        when :encrypted
   11:          raw_hash = Chef::DataBagItem.load(data_bag_name, data_bag_item)
   12:          secret = Chef::EncryptedDataBagItem.load_secret
   13:          Chef::EncryptedDataBagItem.new(raw_hash, secret)
   14:        when :vault
   15:          chef_vault_item(data_bag_name, data_bag_item)
   16:        end

  System Info:
  ------------
  chef_version=14.11.21
  platform=ubuntu
  platform_version=18.04
  ruby=ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
  program_name=chef-client worker: ppid=21192;start=17:28:13;
  executable=/opt/chef/bin/chef-client
```


foodcritic and rubocop returned errors unrelated to this change.  kitchen errored out on

```
       ---- Begin output of ["yum", "--nogpgcheck", ">", "/tmp/uchiwa_pkg.log", "-y", "install", "uchiwa-1:0.23.1-1.x86_64"] ----
       STDOUT: Loaded plugins: fastestmirror
       STDERR: No such command: >. Please use /bin/yum --help
       ---- End output of ["yum", "--nogpgcheck", ">", "/tmp/uchiwa_pkg.log", "-y", "install", "uchiwa-1:0.23.1-1.x86_64"] ----
```

This is a long way of saying I didn't do much testing.

### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable